### PR TITLE
Better buffer reuse

### DIFF
--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -26,10 +26,12 @@ Reader.prototype.write = function(newBuffer) {
   var reuseBuffer = (this._offset >= newBuffer.length);
 
   if (reuseBuffer) {
-    // move bytes from offset to the beginning
-    this._buffer.copy(this._buffer, 0, this._offset);
+    // move unread bytes forward to make room for the new
+    this._buffer.copy(this._buffer, this._offset - newBuffer.length, this._offset);
+    this._offset -= newBuffer.length;
+
     // add the new bytes at the end
-    newBuffer.copy(this._buffer, bytesAhead);
+    newBuffer.copy(this._buffer, this._buffer.length - newBuffer.length);
   } else {
     var oldBuffer = this._buffer;
 
@@ -39,9 +41,8 @@ Reader.prototype.write = function(newBuffer) {
     // copy the old and new buffer into it
     oldBuffer.copy(this._buffer, 0, this._offset);
     newBuffer.copy(this._buffer, bytesAhead);
+    this._offset = 0;
   }
-
-  this._offset = 0;
 
   return !this._paused;
 };

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -168,5 +168,7 @@ Reader.prototype._nullDistance = function() {
 
 Reader.prototype.buffer = function(bytes) {
   this._offset += bytes;
-  return this._buffer.slice(this._offset - bytes, this._offset);
+  var ret = new Buffer(bytes);
+  this._buffer.copy(ret, 0, this._offset -  bytes, this._offset);
+  return ret;
 };

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -37,7 +37,7 @@ Reader.prototype.write = function(newBuffer) {
     this._buffer = new Buffer(bytesAhead + newBuffer.length);
 
     // copy the old and new buffer into it
-    oldBuffer.copy(this._buffer, this._offset);
+    oldBuffer.copy(this._buffer, 0, this._offset);
     newBuffer.copy(this._buffer, bytesAhead);
   }
 

--- a/test/unit/test-Reader.js
+++ b/test/unit/test-Reader.js
@@ -77,6 +77,15 @@ test('Read Methods', {
     assert.equal(reader.bytesAhead(), 2);
   },
 
+  'bytesAhead: reports correctly with smaller buffer': function() {
+    var reader = new Reader();
+
+    reader.write(new Buffer([1, 2]));
+    reader.buffer(2);
+    reader.write(new Buffer([3]));
+    assert.equal(reader.bytesAhead(), 1);
+  },
+
   'uint8': function() {
     var buffer = new Buffer([1, 127, 128, 255]);
     var reader = new Reader(buffer);

--- a/test/unit/test-Reader.js
+++ b/test/unit/test-Reader.js
@@ -242,6 +242,12 @@ test('Read Methods', {
     assert.deepEqual(reader.buffer(3), new Buffer([1, 2, 3]));
     assert.deepEqual(reader.buffer(2), new Buffer([4, 5]));
   },
+  'buffer: return a copy' : function () {
+    var reader = new Reader(new Buffer([1]));
+    var origResult = reader.buffer(1);
+    reader.write(new Buffer([2]));
+    assert.deepEqual(origResult, new Buffer([1]));
+  }
 });
 
 function testParseFixedLengthAsciiWith(encoding) {

--- a/test/unit/test-Reader.js
+++ b/test/unit/test-Reader.js
@@ -63,6 +63,18 @@ test('WritableStream interface', {
     assert.equal(reader.uint8(), 3);
     assert.equal(reader.uint8(), 4);
   },
+
+  'write: grows buffer if neccessary': function() {
+    var reader = new Reader();
+
+    reader.write(new Buffer([1, 2]));
+    assert.equal(reader.uint8(), 1);
+    reader.write(new Buffer([3, 4, 5]));
+    assert.equal(reader.uint8(), 2);
+    assert.equal(reader.uint8(), 3);
+    assert.equal(reader.uint8(), 4);
+    assert.equal(reader.uint8(), 5);
+  },
 });
 
 test('Read Methods', {


### PR DESCRIPTION
here is the proper fix for #1 based on your idea (refilling the buffer from the right).
Along the way I found the reason for my buffer corruption; Reader.buffer returns a copy now, not a slice that my harm the internal buffer when messed with.
