### PR TITLE
copy, don't slice the return buffer

### DIFF
--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -168,5 +168,7 @@ Reader.prototype._nullDistance = function() {
 
 Reader.prototype.buffer = function(bytes) {
   this._offset += bytes;
-  return this._buffer.slice(this._offset - bytes, this._offset);
+  var ret = new Buffer(bytes);
+  this._buffer.copy(ret, 0, this._offset -  bytes, this._offset);
+  return ret;
 };

--- a/test/unit/test-Reader.js
+++ b/test/unit/test-Reader.js
@@ -242,6 +242,12 @@ test('Read Methods', {
     assert.deepEqual(reader.buffer(3), new Buffer([1, 2, 3]));
     assert.deepEqual(reader.buffer(2), new Buffer([4, 5]));
   },
+  'buffer: return a copy' : function () {
+    var reader = new Reader(new Buffer([1]));
+    var origResult = reader.buffer(1);
+    reader.write(new Buffer([2]));
+    assert.deepEqual(origResult, new Buffer([1]));
+  }
 });
 
 function testParseFixedLengthAsciiWith(encoding) {


### PR DESCRIPTION
Here is the second half of #2, make buffer() return a copy of the internal buffer.
