### PR TITLE
implements compact and options{compact:true}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+   - 0.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,6 @@ If you are looking for something to work on, here are a few things I'd like to
 see in this module:
 
 * Implement benchmark suite (with some nice R analysis)
-* Implement `reader.compact()` and/or `new Reader({compact: true})`. Allows for
-  the internal `this._buffer` to shrink. (The current behavior is to grow the
-  internal buffer until it can hold the biggest buffer passed into `write()`).
 * Implement Writer class. Will probably create many internal buffers and flatten
   them into one at the end. Should also support to be initialized with a length
   in which case small buffers are not created all the time.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ their sequences.
 
 ## Reader API
 
+### reader = createReader([buffer] | [options])
+
+Creates a reader with an optional buffer or options hash.
+When using the options hash, you can still supply a buffer with key `buffer`.
+
+#### options
+
+* `buffer` start with the supplied buffer
+* `offset` start reading at the specified offset of the buffer
+* `compact` if true, the internal buffer will be garbage collected on
+  every write operation. See also: method compact()
+
+
 ### reader.write(buffer)
 
 Appends the given `buffer` to the internal buffer. Whenever possible, existing
@@ -99,6 +112,11 @@ Returns the next `bytes` as a buffer.
 ### reader.skip(bytes)
 
 Skips `bytes` bytes of the buffer.
+
+### reader.compact()
+
+Force a compaction of the internal buffer to the maximum size needed,
+discaring data already read.
 
 
 ## Writer API

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Skips `bytes` bytes of the buffer.
 
 ### reader.compact()
 
-Force a compaction of the internal buffer to the maximum size needed,
+Force a compaction of the internal buffer to the minimum size needed,
 discarding data already read.
 
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Skips `bytes` bytes of the buffer.
 ### reader.compact()
 
 Force a compaction of the internal buffer to the maximum size needed,
-discaring data already read.
+discarding data already read.
 
 
 ## Writer API

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -16,6 +16,7 @@ function Reader(options) {
 
   this._buffer = options.buffer || new Buffer(0);
   this._offset = options.offset || 0;
+  this._compact = options.compact || false;
   this._paused = false;
 }
 
@@ -32,6 +33,9 @@ Reader.prototype.write = function(newBuffer) {
 
     // add the new bytes at the end
     newBuffer.copy(this._buffer, this._buffer.length - newBuffer.length);
+    if (this._compact) {
+        this.compact();
+    }
   } else {
     var oldBuffer = this._buffer;
 
@@ -178,4 +182,12 @@ Reader.prototype.skip = function(bytes) {
         this.emit('error', new Error('tried to skip outsite of the buffer'));
     }
     this._offset += bytes;
+};
+
+Reader.prototype.compact = function() {
+    if (this.offset < 1) {
+        return;
+    }
+    this._buffer = this._buffer.slice(this._offset);
+    this._offset = 0;
 };

--- a/test/unit/test-Reader.js
+++ b/test/unit/test-Reader.js
@@ -258,6 +258,36 @@ test('Read Methods', {
   }
 });
 
+test('Meta Methods', {
+    'compact' : function() {
+        var reader = new Reader(new Buffer([1, 2, 3, 4, 5]));
+        reader.buffer(2);
+        assert.equal(reader.bytesBuffered(), 5);
+        reader.compact();
+        assert.equal(reader.bytesBuffered(), 3);
+        assert.deepEqual(reader.buffer(3), new Buffer([3, 4, 5]));
+    },
+
+    'compactOption disabled does not shrink buffer' : function() {
+        var reader = new Reader(new Buffer([1, 2, 3, 4, 5]));
+        reader.buffer(5);
+        reader.write(new Buffer([6]));
+        assert.equal(reader.bytesBuffered(), 5);
+    },
+
+    'compactOption enable does shrink buffer' : function() {
+        var reader = new Reader({
+            buffer : new Buffer([1, 2, 3, 4, 5]),
+            compact : true
+        });
+        reader.buffer(5);
+        reader.write(new Buffer([6]));
+        assert.equal(reader.bytesBuffered(), 1);
+    }
+
+});
+
+
 function testParseFixedLengthAsciiWith(encoding) {
   return function() {
     var buffer = new Buffer([


### PR DESCRIPTION
@felixge: care to comment on this?

I decided only to compact on buffer-reusing writes for now. Compacting on every read felt excessive, but then again, slice() is very efficient. What do you think?
