### PR TITLE
implement full spec for writable streams

### DIFF
--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -1,12 +1,12 @@
 // vim: ts=2:sw=2
 
 var util         = require('util');
-var EventEmitter = require('events').EventEmitter;
+var Stream       = require('stream').Stream;
 
 module.exports = Reader;
-util.inherits(Reader, EventEmitter);
+util.inherits(Reader, Stream);
 function Reader(options) {
-  EventEmitter.call(this);
+  Stream.call(this);
 
   if (Buffer.isBuffer(options)) {
     options = {buffer: options};
@@ -17,9 +17,9 @@ function Reader(options) {
   this.writable = true;
 
   this._buffer = options.buffer || new Buffer(0);
-  this._offset = options.offset || 0;
   this._compact = options.compact || false;
   this._paused = false;
+  this._setOffset(options.offset || 0);
 }
 
 Reader.prototype.write = function(newBuffer) {
@@ -28,10 +28,17 @@ Reader.prototype.write = function(newBuffer) {
   // existing buffer has enough space in the beginning?
   var reuseBuffer = (this._offset >= newBuffer.length);
 
+  if (!this.writable) {
+    var err = new Error('stream not writable');
+    err.code = 'EPIPE';
+    this.emit('error', err);
+    return false;
+  }
+
   if (reuseBuffer) {
     // move unread bytes forward to make room for the new
     this._buffer.copy(this._buffer, this._offset - newBuffer.length, this._offset);
-    this._offset -= newBuffer.length;
+    this._moveOffset(- newBuffer.length);
 
     // add the new bytes at the end
     newBuffer.copy(this._buffer, this._buffer.length - newBuffer.length);
@@ -47,7 +54,7 @@ Reader.prototype.write = function(newBuffer) {
     // copy the old and new buffer into it
     oldBuffer.copy(this._buffer, 0, this._offset);
     newBuffer.copy(this._buffer, bytesAhead);
-    this._offset = 0;
+    this._setOffset(0);
   }
 
   return !this._paused;
@@ -59,6 +66,7 @@ Reader.prototype.pause = function() {
 
 Reader.prototype.resume = function() {
   this._paused = false;
+  this.emit('drain');
 };
 
 Reader.prototype.bytesAhead = function() {
@@ -70,71 +78,59 @@ Reader.prototype.bytesBuffered = function() {
 };
 
 Reader.prototype.uint8 = function() {
-  return this._buffer.readUInt8(this._offset++);
+  return this._buffer.readUInt8(this._moveOffset(1));
 };
 
 Reader.prototype.int8 = function() {
-  return this._buffer.readInt8(this._offset++);
+  return this._buffer.readInt8(this._moveOffset(1));
 };
 
 Reader.prototype.uint16BE = function() {
-  this._offset += 2;
-  return this._buffer.readUInt16BE(this._offset - 2);
+  return this._buffer.readUInt16BE(this._moveOffset(2));
 };
 
 Reader.prototype.int16BE = function() {
-  this._offset += 2;
-  return this._buffer.readInt16BE(this._offset - 2);
+  return this._buffer.readInt16BE(this._moveOffset(2));
 };
 
 Reader.prototype.uint16LE = function() {
-  this._offset += 2;
-  return this._buffer.readUInt16LE(this._offset - 2);
+  return this._buffer.readUInt16LE(this._moveOffset(2));
 };
 
 Reader.prototype.int16LE = function() {
-  this._offset += 2;
-  return this._buffer.readInt16LE(this._offset - 2);
+  return this._buffer.readInt16LE(this._moveOffset(2));
 };
 
 Reader.prototype.uint32BE = function() {
-  this._offset += 4;
-  return this._buffer.readUInt32BE(this._offset - 4);
+  return this._buffer.readUInt32BE(this._moveOffset(4));
 };
 
 Reader.prototype.int32BE = function() {
-  this._offset += 4;
-  return this._buffer.readInt32BE(this._offset - 4);
+  return this._buffer.readInt32BE(this._moveOffset(4));
 };
 
 Reader.prototype.uint32LE = function() {
-  this._offset += 4;
-  return this._buffer.readUInt32LE(this._offset - 4);
+  return this._buffer.readUInt32LE(this._moveOffset(4));
 };
 
 Reader.prototype.int32LE = function() {
-  this._offset += 4;
-  return this._buffer.readInt32LE(this._offset - 4);
+  return this._buffer.readInt32LE(this._moveOffset(4));
 };
 
 Reader.prototype.float32BE = function() {
-  this._offset += 4;
-  return this._buffer.readFloatBE(this._offset - 4);
+  return this._buffer.readFloatBE(this._moveOffset(4));
 };
 
 Reader.prototype.float32LE = function() {
-  this._offset += 4;
-  return this._buffer.readFloatLE(this._offset - 4);
+  return this._buffer.readFloatLE(this._moveOffset(4));
 };
 
 Reader.prototype.double64BE = function() {
-  this._offset += 8;
-  return this._buffer.readDoubleBE(this._offset - 8);
+  return this._buffer.readDoubleBE(this._moveOffset(8));
 };
 
 Reader.prototype.double64LE = function() {
-  this._offset += 8;
-  return this._buffer.readDoubleLE(this._offset - 8);
+  return this._buffer.readDoubleLE(this._moveOffset(8));
 };
 
 Reader.prototype.ascii = function(bytes) {
@@ -152,12 +148,12 @@ Reader.prototype._string = function(encoding, bytes) {
   }
 
   var offset = this._offset;
-  this._offset += bytes;
+  this._moveOffset(bytes);
 
   var value = this._buffer.toString(encoding, offset, this._offset);
 
   if (nullTerminated) {
-    this._offset++;
+    this._moveOffset(1);
   }
 
   return value;
@@ -173,7 +169,7 @@ Reader.prototype._nullDistance = function() {
 };
 
 Reader.prototype.buffer = function(bytes) {
-  this._offset += bytes;
+  this._moveOffset(bytes);
   var ret = new Buffer(bytes);
   this._buffer.copy(ret, 0, this._offset -  bytes, this._offset);
   return ret;
@@ -183,7 +179,7 @@ Reader.prototype.skip = function(bytes) {
   if (bytes > this.bytesAhead() || bytes < 0) {
     this.emit('error', new Error('tried to skip outsite of the buffer'));
   }
-  this._offset += bytes;
+  this._moveOffset(bytes);
 };
 
 Reader.prototype.compact = function() {
@@ -191,5 +187,47 @@ Reader.prototype.compact = function() {
     return;
   }
   this._buffer = this._buffer.slice(this._offset);
+  this._setOffset(0);
+};
+
+Reader.prototype.end = function(newBuffer) {
+  if (undefined !== newBuffer) {
+    this.write(newBuffer);
+  }
+  this.writable = false;
+  if (0 === this.bytesAhead()) {
+    this.destroy();
+  }
+  return true;
+};
+
+Reader.prototype.destroy = function() {
+  this._buffer = null;
   this._offset = 0;
+  this.writable = false;
+  this.emit('close');
+};
+
+
+Reader.prototype._setOffset = function(offset) {
+  var that = this;
+  if ((offset < 0) || (offset > this.bytesBuffered())) {
+    this.emit('error', new Error('tried to read outsite of buffer boundary'));
+  }
+  this._offset = offset;
+
+  // handle end()
+  if (! this.writable && (this.bytesAhead() === 0)) {
+    // delay since a read may be in progress
+    process.nextTick(function () {
+      that.destroy();
+    });
+  }
+  return offset;
+};
+
+Reader.prototype._moveOffset = function(relativeOffset) {
+  var oldOffset = this._offset;
+  this._setOffset(oldOffset + relativeOffset);
+  return oldOffset;
 };

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -176,7 +176,7 @@ Reader.prototype.buffer = function(bytes) {
 };
 
 Reader.prototype.skip = function(bytes) {
-  if (bytes > this.bytesAhead() || bytes < 0) {
+  if (bytes < 0) {
     this.emit('error', new Error('tried to skip outsite of the buffer'));
   }
   this._moveOffset(bytes);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "optionalDependencies": {},
   "devDependencies": {
     "utest": "0.0.6",
-    "urun": "0.0.6"
+    "urun": "0.0.6",
+    "stream-tester": "0.0.2",
+    "stream-spec": "~0.3.1"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
I had a go at implementing the full spec for writable streams. Is this overkill?

Things done:
- inherit from Stream instead of only EventEmitter
- refactored any changes to _offset into methods _moveOffset and _setOffset
- implemented end() and destroy()
- emit E_PIPE when attempted to write after end()
- emit drain on resume
- added test against stream-spec by @dominictarr
