### PR TITLE
Performance Enhancements

### DIFF
--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -225,16 +225,21 @@ Reader.prototype.destroy = function() {
 
 
 Reader.prototype._setOffset = function(offset) {
-  var that = this;
   this._offset = offset;
 
   // handle end()
-  if (! this.writable && (this.bytesAhead() === 0)) {
-    // delay since a read may be in progress
-    process.nextTick(function () {
-      that.destroy();
-    });
+  if (! this.writable) {
+    this._maybeDestroy();
   }
+};
+
+Reader.prototype._maybeDestroy = function () {
+  var that = this;
+  process.nextTick(function () {
+    if (that.bytesAhead() === 0) {
+      that.destroy();
+    }
+  });
 };
 
 Reader.prototype._moveOffset = function(relativeOffset) {

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -233,9 +233,6 @@ Reader.prototype.destroy = function() {
 
 Reader.prototype._setOffset = function(offset) {
   var that = this;
-  if ((offset < 0) || (offset > this.bytesBuffered())) {
-    this.emit('error', new Error('tried to read outsite of buffer boundary'));
-  }
   this._offset = offset;
 
   // handle end()

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -213,6 +213,8 @@ Reader.prototype.end = function(newBuffer) {
   if (0 === this.bytesAhead()) {
     this.destroy();
   }
+  // performance hack: switch to slightly slower version of _setOffset()
+  this._setOffset = this._setOffsetNotWritable;
   return true;
 };
 
@@ -225,6 +227,10 @@ Reader.prototype.destroy = function() {
 
 
 Reader.prototype._setOffset = function(offset) {
+  this._offset = offset;
+};
+
+Reader.prototype._setOffsetNotWritable = function(offset) {
   this._offset = offset;
 
   // handle end()

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -28,13 +28,6 @@ Reader.prototype.write = function(newBuffer) {
   // existing buffer has enough space in the beginning?
   var reuseBuffer = (this._offset >= newBuffer.length);
 
-  if (!this.writable) {
-    var err = new Error('stream not writable');
-    err.code = 'EPIPE';
-    this.emit('error', err);
-    return false;
-  }
-
   if (reuseBuffer) {
     // move unread bytes forward to make room for the new
     this._buffer.copy(this._buffer, this._offset - newBuffer.length, this._offset);

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -235,7 +235,6 @@ Reader.prototype._setOffset = function(offset) {
       that.destroy();
     });
   }
-  return offset;
 };
 
 Reader.prototype._moveOffset = function(relativeOffset) {

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -78,43 +78,64 @@ Reader.prototype.bytesBuffered = function() {
 };
 
 Reader.prototype.uint8 = function() {
-  return this._buffer.readUInt8(this._moveOffset(1));
+  return this._buffer[this._moveOffset(1)];
 };
 
 Reader.prototype.int8 = function() {
-  return this._buffer.readInt8(this._moveOffset(1));
+  var unsigned = this.uint8();
+  return (unsigned & 0x80) ? ((0xff - unsigned + 1) * -1) : unsigned;
 };
 
 Reader.prototype.uint16BE = function() {
-  return this._buffer.readUInt16BE(this._moveOffset(2));
+  this._moveOffset(2);
+  return (this._buffer[this._offset - 2] << 8) | this._buffer[this._offset - 1];
 };
 
 Reader.prototype.int16BE = function() {
-  return this._buffer.readInt16BE(this._moveOffset(2));
+  var unsigned = this.uint16BE();
+  return unsigned & 0x8000 ? (0xffff - unsigned + 1) * -1 : unsigned;
 };
 
 Reader.prototype.uint16LE = function() {
-  return this._buffer.readUInt16LE(this._moveOffset(2));
+  this._moveOffset(2);
+  return this._buffer[this._offset - 2] | this._buffer[this._offset - 1] << 8;
 };
 
 Reader.prototype.int16LE = function() {
-  return this._buffer.readInt16LE(this._moveOffset(2));
+  var unsigned = this.uint16LE();
+  return unsigned & 0x8000 ? (0xffff - unsigned + 1) * -1 : unsigned;
 };
 
 Reader.prototype.uint32BE = function() {
-  return this._buffer.readUInt32BE(this._moveOffset(4));
+  this._moveOffset(4);
+
+  return (
+    this._buffer[this._offset - 3] << 16 |
+    this._buffer[this._offset - 2] <<  8 |
+    this._buffer[this._offset - 1] +
+    (this._buffer[this._offset - 4] << 24)
+  ) >>> 0;
 };
 
 Reader.prototype.int32BE = function() {
-  return this._buffer.readInt32BE(this._moveOffset(4));
+  var unsigned = this.uint32BE();
+  return unsigned & 0x80000000 ? (0xffffffff - unsigned + 1) * -1 : unsigned;
 };
 
 Reader.prototype.uint32LE = function() {
-  return this._buffer.readUInt32LE(this._moveOffset(4));
+  this._moveOffset(4);
+
+  return (
+    this._buffer[this._offset - 2] << 16 |
+    this._buffer[this._offset - 3] <<  8 |
+    this._buffer[this._offset - 4] +
+    (this._buffer[this._offset - 1] << 24)
+  ) >>> 0;
 };
 
 Reader.prototype.int32LE = function() {
-  return this._buffer.readInt32LE(this._moveOffset(4));
+  var unsigned = this.uint32LE();
+  return unsigned & 0x80000000 ? (0xffffffff - unsigned + 1) * -1 : unsigned;
 };
 
 Reader.prototype.float32BE = function() {

--- a/lib/Reader.js
+++ b/lib/Reader.js
@@ -249,7 +249,6 @@ Reader.prototype._maybeDestroy = function () {
 };
 
 Reader.prototype._moveOffset = function(relativeOffset) {
-  var oldOffset = this._offset;
-  this._setOffset(oldOffset + relativeOffset);
-  return oldOffset;
+  this._setOffset(this._offset + relativeOffset);
+  return this._offset - relativeOffset;
 };

--- a/test/unit/test-Reader.js
+++ b/test/unit/test-Reader.js
@@ -333,8 +333,6 @@ test('Read Methods', {
     var reader = new Reader(new Buffer([1, 2, 3, 4, 5]));
     reader.skip(2);
     assert.deepEqual(reader.buffer(3), new Buffer([3, 4, 5]));
-    assert.throws(function() { reader.skip(1); });
-    assert.throws(function() { reader.skip(-1); });
   }
 });
 

--- a/test/unit/test-Reader.js
+++ b/test/unit/test-Reader.js
@@ -229,11 +229,12 @@ test('Read Methods', {
   },
 
   'uint32BE': function() {
-    var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
+    var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 255, 254, 253, 252]);
     var reader = new Reader(buffer);
 
     assert.equal(reader.uint32BE(), 16909060);
     assert.equal(reader.uint32BE(), 84281096);
+    assert.equal(reader.uint32BE(), 4294901244);
   },
 
   'int32BE': function() {
@@ -245,11 +246,12 @@ test('Read Methods', {
   },
 
   'uint32LE': function() {
-    var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8]);
+    var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 252, 253, 254, 255]);
     var reader = new Reader(buffer);
 
     assert.equal(reader.uint32LE(), 67305985);
     assert.equal(reader.uint32LE(), 134678021);
+    assert.equal(reader.uint32LE(), 4294901244);
   },
 
   'int32LE': function() {


### PR DESCRIPTION
Here is something to review while waiting for your flight ;-)

These patches have actually been verified with the mysql benchmark, which I'll push very soon.

I removed some of the checks I introduced for the full streaming support, since they din't add much functionality, but are measurably slow. And then there's the slightly hackish 37df5f0. With these changes, performance is back on pre-stream levels.

Using the array access to the buffer (f37f923) gives another speed boost, making this branch the fastest buffy yet.

You'll probably want me to break this up into chunks. hacks into one pr, array access into another?
